### PR TITLE
Use setState()'s "updater" version

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -63,26 +63,29 @@ class App extends Component {
   onAdd() {
     globalId ++;
 
-    this.setState({
+    this.setState((state) => ({
       todos: [
         {id: globalId, name: '', done: false},
-        ...this.state.todos,
+        ...state.todos,
       ]
-    })
+    }))
   }
 
   handleChange(todo, name) {
-    const todos = this.state.todos.map(td => {
-      if (td === todo) {
-        return {
-          ...td,
-          name
+    this.setState((state) => {
+      
+      const todos = state.todos.map(td => {
+        if (td === todo) {
+          return {
+            ...td,
+            name
+          }
         }
-      }
-      return td;
+        return td;
+      })
+      
+      return { todos }
     })
-
-    this.setState({ todos })
   }
 
   handleCheckbox(event) {


### PR DESCRIPTION
When doing a React "setState()" function call, and the new state is calculated using the old state, it's best to use setState()'s alternate syntax where you provide it with a `(prevState, props) => newstate` callback function instead of providing it with a `newstate` object directly. This prevents problems that can come up due to the asynchronous batched way React applies state updates.

See: https://medium.com/@wisecobbler/using-a-function-in-setstate-instead-of-an-object-1f5cfd6e55d1